### PR TITLE
Fix: Remove white fill from SVG copy icons

### DIFF
--- a/client/src/components/wallet/components/QRCodeModal.tsx
+++ b/client/src/components/wallet/components/QRCodeModal.tsx
@@ -14,7 +14,7 @@ const getQRCodeUrl = (address: string): string => {
 // Icons with Blue Theme
 const CopyIcon = () => (
   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect x="9" y="9" width="12" height="12" rx="2" stroke="#3b82f6" strokeWidth="2" fill="#eff6ff"/>
+    <rect x="9" y="9" width="12" height="12" rx="2" stroke="#3b82f6" strokeWidth="2" fill="none"/>
     <path d="M5 15H4C2.89543 15 2 14.1046 2 13V4C2 2.89543 2.89543 2 4 2H13C14.1046 2 15 2.89543 15 4V5" stroke="#3b82f6" strokeWidth="2"/>
   </svg>
 );

--- a/client/src/components/wallet/components/WalletHeader.tsx
+++ b/client/src/components/wallet/components/WalletHeader.tsx
@@ -24,7 +24,7 @@ const QRCodeIcon = () => (
 
 const CopyIcon = () => (
   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <rect x="9" y="9" width="12" height="12" rx="2" stroke="#3b82f6" strokeWidth="2" fill="#eff6ff"/>
+    <rect x="9" y="9" width="12" height="12" rx="2" stroke="#3b82f6" strokeWidth="2" fill="none"/>
     <path d="M5 15H4C2.89543 15 2 14.1046 2 13V4C2 2.89543 2.89543 2 4 2H13C14.1046 2 15 2.89543 15 4V5" stroke="#3b82f6" strokeWidth="2"/>
   </svg>
 );


### PR DESCRIPTION
## 🎯 **Problem**

The SVG copy icons in both WalletHeader and QRCodeModal components had a white/light blue fill (`#eff6ff`) that was visually undesirable.

## 🔧 **Solution**

Removed the white fill from both copy icons by changing `fill="#eff6ff"` to `fill="none"`.

## 📝 **Changes Made**

### Files Modified:
- `client/src/components/wallet/components/WalletHeader.tsx`
- `client/src/components/wallet/components/QRCodeModal.tsx`

### Specific Changes:
- **Before**: `<rect ... fill="#eff6ff"/>`
- **After**: `<rect ... fill="none"/>`

## ✨ **Result**

- Copy icons now display as **blue outline only** (`stroke="#3b82f6"`)
- **No white/light blue background fill**
- **Maintains blue theme consistency**
- **Same functionality** - icons remain fully clickable
- **Better visual appearance** without unwanted white color

## 🧪 **Testing**

- [x] Icons display correctly in WalletHeader component
- [x] Icons display correctly in QRCodeModal component
- [x] Copy functionality remains intact
- [x] Blue theme consistency maintained
- [x] No visual regressions

## 📸 **Visual Impact**

The copy icons now appear as clean blue outlines without any white fill, providing a cleaner and more consistent visual experience with the overall blue theme of the application.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author