### PR TITLE
feat: Make NetworkBadge more compact and full-width

### DIFF
--- a/client/src/components/wallet/components/NetworkBadge.tsx
+++ b/client/src/components/wallet/components/NetworkBadge.tsx
@@ -35,16 +35,16 @@ const NetworkBadgeContainer = styled.div<{ networkColor: string }>`
   justify-content: center;
   background: ${props => props.networkColor};
   color: ${theme.colors.text.inverse};
-  padding: ${theme.spacing[3]} ${theme.spacing[5]};
-  margin: ${theme.spacing[4]};
-  border-radius: ${theme.borderRadius.full};
+  padding: ${theme.spacing[2]} ${theme.spacing[3]};
+  margin: 0;
+  border-radius: ${theme.borderRadius.md};
   font-size: ${theme.typography.fontSize.xs};
   font-weight: ${theme.typography.fontWeight.bold};
   text-transform: uppercase;
   letter-spacing: 1px;
   box-shadow: ${theme.shadows.sm};
   border: 1px solid rgba(255, 255, 255, 0.1);
-  width: calc(100% - ${theme.spacing[8]});
+  width: 100%;
   box-sizing: border-box;
   transition: ${theme.transitions.fast};
 


### PR DESCRIPTION
## 🎯 Overview

Simple improvement to the NetworkBadge component in the left sidebar to make it more compact and stretch the full width of the menu.

## ✨ Changes Made

### 📏 Reduced Height
- **Padding**: Changed from `spacing[3]` to `spacing[2]` for less vertical space
- **More compact**: Badge now takes up less vertical space in the sidebar

### 📐 Full Width Stretch
- **Width**: Changed from `calc(100% - spacing[8])` to `100%`
- **Margin**: Removed margin (`margin: 0`) to allow full stretch
- **Rectangle shape**: Changed from `borderRadius.full` to `borderRadius.md`

### 🎨 Visual Result
- **Before**: Rounded badge with margins and larger padding
- **After**: Full-width rectangular badge with compact height
- **Maintains**: All existing colors, hover effects, and functionality

## 🔧 Technical Details

```typescript
// Key changes in NetworkBadgeContainer:
padding: ${theme.spacing[2]} ${theme.spacing[3]};  // Reduced from spacing[3]
margin: 0;                                          // Removed margin
border-radius: ${theme.borderRadius.md};           // Changed from full
width: 100%;                                        // Full width stretch
```

## ✅ Testing

- ✅ Application compiles successfully
- ✅ NetworkBadge displays correctly in sidebar
- ✅ All network colors and functionality preserved
- ✅ Hover effects still work as expected
- ✅ Responsive design maintained

---

*This is a minimal, focused improvement that makes the network badge more streamlined and better integrated with the left menu layout.*

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author