### PR TITLE
Update vito-contracts submodule and Safe contract ABI to latest version

### DIFF
--- a/client/src/contracts/abis.ts
+++ b/client/src/contracts/abis.ts
@@ -603,143 +603,1006 @@ export const SAFE_TX_POOL_REGISTRY_EXTENDED_ABI = [
   }
 ];
 
-// Safe Wallet contract ABI (core methods we need)
+// Safe Wallet contract ABI (latest version from vito-contracts submodule)
+// Updated from Safe v1.4.1 with complete function and event definitions
 export const SAFE_ABI = [
   {
-    "type": "function",
-    "name": "getOwners",
+    "type": "constructor",
     "inputs": [],
-    "outputs": [{"name": "", "type": "address[]"}],
-    "stateMutability": "view"
+    "stateMutability": "nonpayable"
   },
   {
-    "type": "function",
-    "name": "getThreshold",
-    "inputs": [],
-    "outputs": [{"name": "", "type": "uint256"}],
-    "stateMutability": "view"
+    "type": "fallback",
+    "stateMutability": "nonpayable"
   },
   {
-    "type": "function",
-    "name": "nonce",
-    "inputs": [],
-    "outputs": [{"name": "", "type": "uint256"}],
-    "stateMutability": "view"
+    "type": "receive",
+    "stateMutability": "payable"
   },
   {
     "type": "function",
     "name": "VERSION",
     "inputs": [],
-    "outputs": [{"name": "", "type": "string"}],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "addOwnerWithThreshold",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_threshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "approveHash",
+    "inputs": [
+      {
+        "name": "hashToApprove",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "approvedHashes",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "changeThreshold",
+    "inputs": [
+      {
+        "name": "_threshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "checkNSignatures",
+    "inputs": [
+      {
+        "name": "dataHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "signatures",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "requiredSignatures",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "checkSignatures",
+    "inputs": [
+      {
+        "name": "dataHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "signatures",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "disableModule",
+    "inputs": [
+      {
+        "name": "prevModule",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "module",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "domainSeparator",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "enableModule",
+    "inputs": [
+      {
+        "name": "module",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "encodeTransactionData",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "operation",
+        "type": "uint8",
+        "internalType": "enum Enum.Operation"
+      },
+      {
+        "name": "safeTxGas",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "baseGas",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasPrice",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasToken",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "refundReceiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_nonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "execTransaction",
     "inputs": [
-      {"name": "to", "type": "address"},
-      {"name": "value", "type": "uint256"},
-      {"name": "data", "type": "bytes"},
-      {"name": "operation", "type": "uint8"},
-      {"name": "safeTxGas", "type": "uint256"},
-      {"name": "baseGas", "type": "uint256"},
-      {"name": "gasPrice", "type": "uint256"},
-      {"name": "gasToken", "type": "address"},
-      {"name": "refundReceiver", "type": "address"},
-      {"name": "signatures", "type": "bytes"}
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "operation",
+        "type": "uint8",
+        "internalType": "enum Enum.Operation"
+      },
+      {
+        "name": "safeTxGas",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "baseGas",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasPrice",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasToken",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "refundReceiver",
+        "type": "address",
+        "internalType": "address payable"
+      },
+      {
+        "name": "signatures",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
     ],
-    "outputs": [{"name": "success", "type": "bool"}],
+    "outputs": [
+      {
+        "name": "success",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "execTransactionFromModule",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "operation",
+        "type": "uint8",
+        "internalType": "enum Enum.Operation"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "success",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
     "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "execTransactionFromModuleReturnData",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "operation",
+        "type": "uint8",
+        "internalType": "enum Enum.Operation"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "success",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "returnData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getChainId",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getModulesPaginated",
+    "inputs": [
+      {
+        "name": "start",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "pageSize",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "array",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "next",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getOwners",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getStorageAt",
+    "inputs": [
+      {
+        "name": "offset",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "length",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getThreshold",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "getTransactionHash",
     "inputs": [
-      {"name": "to", "type": "address"},
-      {"name": "value", "type": "uint256"},
-      {"name": "data", "type": "bytes"},
-      {"name": "operation", "type": "uint8"},
-      {"name": "safeTxGas", "type": "uint256"},
-      {"name": "baseGas", "type": "uint256"},
-      {"name": "gasPrice", "type": "uint256"},
-      {"name": "gasToken", "type": "address"},
-      {"name": "refundReceiver", "type": "address"},
-      {"name": "nonce", "type": "uint256"}
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "operation",
+        "type": "uint8",
+        "internalType": "enum Enum.Operation"
+      },
+      {
+        "name": "safeTxGas",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "baseGas",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasPrice",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasToken",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "refundReceiver",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_nonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
-    "outputs": [{"name": "", "type": "bytes32"}],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isModuleEnabled",
+    "inputs": [
+      {
+        "name": "module",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
     "stateMutability": "view"
   },
   {
     "type": "function",
     "name": "isOwner",
-    "inputs": [{"name": "owner", "type": "address"}],
-    "outputs": [{"name": "", "type": "bool"}],
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
     "stateMutability": "view"
   },
-  // Events for tracking executed transactions
   {
-    "type": "event",
-    "name": "ExecutionSuccess",
-    "inputs": [
-      {"name": "txHash", "type": "bytes32", "indexed": true},
-      {"name": "payment", "type": "uint256", "indexed": false}
-    ]
+    "type": "function",
+    "name": "nonce",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    "type": "event",
-    "name": "ExecutionFailure",
+    "type": "function",
+    "name": "removeOwner",
     "inputs": [
-      {"name": "txHash", "type": "bytes32", "indexed": true},
-      {"name": "payment", "type": "uint256", "indexed": false}
-    ]
+      {
+        "name": "prevOwner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_threshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
-    "type": "event",
-    "name": "SafeSetup",
+    "type": "function",
+    "name": "setFallbackHandler",
     "inputs": [
-      {"name": "initiator", "type": "address", "indexed": true},
-      {"name": "owners", "type": "address[]", "indexed": false},
-      {"name": "threshold", "type": "uint256", "indexed": false},
-      {"name": "initializer", "type": "address", "indexed": false},
-      {"name": "fallbackHandler", "type": "address", "indexed": false}
-    ]
+      {
+        "name": "handler",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
+  {
+    "type": "function",
+    "name": "setGuard",
+    "inputs": [
+      {
+        "name": "guard",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setup",
+    "inputs": [
+      {
+        "name": "_owners",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "_threshold",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "fallbackHandler",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "paymentToken",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "payment",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "paymentReceiver",
+        "type": "address",
+        "internalType": "address payable"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "signedMessages",
+    "inputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "simulateAndRevert",
+    "inputs": [
+      {
+        "name": "targetContract",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "calldataPayload",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "swapOwner",
+    "inputs": [
+      {
+        "name": "prevOwner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "oldOwner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "newOwner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  // Events
   {
     "type": "event",
     "name": "AddedOwner",
     "inputs": [
-      {"name": "owner", "type": "address", "indexed": true}
-    ]
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
   },
   {
     "type": "event",
-    "name": "RemovedOwner",
+    "name": "ApproveHash",
     "inputs": [
-      {"name": "owner", "type": "address", "indexed": true}
-    ]
+      {
+        "name": "approvedHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ChangedFallbackHandler",
+    "inputs": [
+      {
+        "name": "handler",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ChangedGuard",
+    "inputs": [
+      {
+        "name": "guard",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
   },
   {
     "type": "event",
     "name": "ChangedThreshold",
     "inputs": [
-      {"name": "threshold", "type": "uint256", "indexed": false}
-    ]
+      {
+        "name": "threshold",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
   },
-  // Guard management functions
-  {
-    "type": "function",
-    "name": "setGuard",
-    "inputs": [{"name": "guard", "type": "address"}],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  // Guard events
   {
     "type": "event",
-    "name": "ChangedGuard",
+    "name": "DisabledModule",
     "inputs": [
-      {"name": "guard", "type": "address", "indexed": true}
-    ]
+      {
+        "name": "module",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EnabledModule",
+    "inputs": [
+      {
+        "name": "module",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ExecutionFailure",
+    "inputs": [
+      {
+        "name": "txHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "payment",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ExecutionFromModuleFailure",
+    "inputs": [
+      {
+        "name": "module",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ExecutionFromModuleSuccess",
+    "inputs": [
+      {
+        "name": "module",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ExecutionSuccess",
+    "inputs": [
+      {
+        "name": "txHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "payment",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RemovedOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SafeReceived",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SafeSetup",
+    "inputs": [
+      {
+        "name": "initiator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "owners",
+        "type": "address[]",
+        "indexed": false,
+        "internalType": "address[]"
+      },
+      {
+        "name": "threshold",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "initializer",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "fallbackHandler",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SignMsg",
+    "inputs": [
+      {
+        "name": "msgHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
   }
 ];
 

--- a/client/src/utils/transactionDecoder.ts
+++ b/client/src/utils/transactionDecoder.ts
@@ -505,7 +505,7 @@ export class TransactionDecoder {
             };
           } catch (e) { break; }
 
-        case '0xe318b52b': // setGuard
+        case '0xe19a9dd9': // setGuard
           try {
             const decoded = safeInterface.decodeFunctionData('setGuard', data);
             return {


### PR DESCRIPTION
## 🔄 Update vito-contracts submodule and Safe contract ABI to latest version

### 📋 Summary
This PR updates the vito-contracts submodule to the latest version and replaces the Safe contract ABI with the complete Safe v1.4.1 specification for improved transaction decoding.

### 🚀 Changes Made

#### 📦 Submodule Update
- **Updated vito-contracts submodule** from `b6aa8b0` to `4f2753d` (latest main branch)
- **Built contracts** using Foundry to generate latest ABIs
- **Tracked submodule update** in git

#### 🔧 Safe Contract ABI Enhancement
- **Replaced existing SAFE_ABI** in `client/src/contracts/abis.ts` with complete Safe v1.4.1 ABI
- **Fixed critical issue**: `execTransaction` stateMutability changed from `"nonpayable"` to `"payable"`
- **Added complete function definitions** including:
  - `encodeTransactionData`
  - `execTransactionFromModule`
  - `execTransactionFromModuleReturnData`
  - `domainSeparator`
  - `getChainId`
  - And many more...
- **Added all Safe contract events** with proper indexing:
  - `ExecutionSuccess`
  - `ExecutionFailure`
  - `SafeSetup`
  - `AddedOwner`
  - `RemovedOwner`
  - `ChangedThreshold`
  - `ChangedGuard`
  - And more...

#### 🔍 Transaction Decoder Fix
- **Fixed setGuard method ID** in `client/src/utils/transactionDecoder.ts`
- **Changed from incorrect `0xe318b52b` to correct `0xe19a9dd9`**
- **Verified method ID** calculated from `setGuard(address)` function signature
- **Tested encoding/decoding** to ensure proper functionality

### 🎯 Impact on Transaction Decoding

#### ✅ Before vs After
**Before:**
- Limited Safe ABI with basic functions only
- `execTransaction` incorrectly marked as `"nonpayable"`
- **setGuard transactions not properly decoded** (wrong method ID)
- Missing many Safe contract functions and events
- Limited transaction decoding capabilities

**After:**
- ✅ Complete Safe v1.4.1 ABI with all functions and events
- ✅ `execTransaction` correctly marked as `"payable"` - **critical for ETH handling**
- ✅ **setGuard transactions now properly decoded** with correct method ID `0xe19a9dd9`
- ✅ Enhanced transaction decoder capabilities
- ✅ Better Safe transaction parsing and display
- ✅ Support for complex Safe operations (modules, delegate calls, etc.)

### 🧪 Testing
- ✅ **Build verification**: Client application compiles successfully
- ✅ **ABI functionality**: Transaction encoding/decoding works correctly
- ✅ **Key functions confirmed**: All essential Safe functions available
- ✅ **Transaction decoding**: Safe execTransaction calls properly decoded
- ✅ **setGuard fix verified**: Method ID encoding/decoding tested and working

### 🔍 Technical Details

The transaction decoder (`client/src/utils/transactionDecoder.ts`) automatically uses the updated ABI when processing Safe transactions:

```typescript
// Detects Safe execTransaction calls (method ID: 0x6a761202)
if (methodId === '0x6a761202') {
  const safeInnerTx = this.decodeSafeExecTransaction(data);
  // Now uses complete Safe v1.4.1 ABI for accurate decoding
}

// Fixed setGuard method ID
case '0xe19a9dd9': // setGuard (was incorrectly 0xe318b52b)
  const decoded = safeInterface.decodeFunctionData('setGuard', data);
  // Now properly decodes setGuard transactions
```

### 🎉 Benefits
1. **Accurate Safe transaction decoding** with proper parameter types
2. **Correct ETH handling** in Safe transactions (due to payable fix)
3. **Proper setGuard transaction decoding** (fixed method ID)
4. **Support for all Safe v1.4.1 features** in the UI
5. **Better transaction transparency** and user experience
6. **Future-proof** contract interaction capabilities

### 📝 Files Changed
- `vito-contracts` (submodule update)
- `client/src/contracts/abis.ts` (complete Safe ABI replacement)
- `client/src/utils/transactionDecoder.ts` (setGuard method ID fix)

---

**Ready for review and testing!** 🚀

This update ensures the UI can properly decode and display Safe transactions using the current Safe wallet contract specifications, including the previously broken setGuard function decoding.