### PR TITLE
Fix setGuard function display in transaction decoder

### DIFF
--- a/client/src/utils/transactionDecoder.ts
+++ b/client/src/utils/transactionDecoder.ts
@@ -612,6 +612,13 @@ export class TransactionDecoder {
       if (registryDecoded) return registryDecoded;
     }
 
+    // Check if this is a Safe contract method
+    // We can identify Safe contracts by checking if they have common Safe method signatures
+    const safeMethodDecoded = this.decodeSafeMethod(methodId, data);
+    if (safeMethodDecoded) {
+      return safeMethodDecoded;
+    }
+
     // Known method IDs for other contracts
     const knownMethods: { [key: string]: { name: string; description: string } } = {
       '0x09959f6b': {


### PR DESCRIPTION
## Problem

The `setGuard` function was displaying as a generic "Function Call (0xe19a9dd9)" instead of showing the proper function name and description in the transaction interface.

## Root Cause

The `decodeSafeMethod` function properly handled the `setGuard` method ID `0xe19a9dd9`, but it was only being called for inner transactions within `execTransaction`. When transactions were made directly to Safe contracts (like setting a guard), the `decodeKnownMethod` function wasn't checking for Safe contract methods.

## Solution

Added Safe contract method detection to the `decodeKnownMethod` function in `client/src/utils/transactionDecoder.ts`:

```typescript
// Check if this is a Safe contract method
const safeMethodDecoded = this.decodeSafeMethod(methodId, data);
if (safeMethodDecoded) {
  return safeMethodDecoded;
}
```

## Changes

- ✅ **Enhanced transaction decoder**: Added Safe method detection to `decodeKnownMethod`
- ✅ **Improved UX**: `setGuard` now displays as "Set Safe Guard" with proper parameter decoding
- ✅ **Backward compatible**: Maintains existing functionality for all other contract types
- ✅ **Tested**: Verified the fix works correctly with comprehensive testing

## Before vs After

**Before**: 
- Display: "Function Call (0xe19a9dd9)"
- No parameter information

**After**:
- Display: "Set Safe Guard"
- Shows guard contract address parameter
- Includes parameter description

## Testing

- ✅ Verified method ID `0xe19a9dd9` matches `setGuard` function
- ✅ Confirmed proper parameter decoding
- ✅ Tested that existing functionality remains intact
- ✅ Application compiles without errors

This fix improves the user experience by providing clear, descriptive information about Safe guard configuration transactions instead of cryptic method IDs.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author