### PR TITLE
Fix: Prioritize trusted contract tokens over pre-defined tokens

### DIFF
--- a/client/src/components/wallet/WalletPage.tsx
+++ b/client/src/components/wallet/WalletPage.tsx
@@ -152,15 +152,24 @@ const WalletPage: React.FC<WalletPageProps> = ({
     refreshTokenBalances();
   };
 
-  // Function to refresh token balances
+  // Function to refresh token balances with trusted contract enhancement
   const refreshTokenBalances = async () => {
     if (!walletAddress) return;
 
     try {
-      console.log('🔄 Refreshing token balances...');
-      const refreshedAssets = await loadTokenBalances(walletAddress, network || 'ethereum');
-      setAssets(refreshedAssets);
-      console.log('✅ Token balances refreshed');
+      console.log('🔄 Refreshing token balances with trusted contracts...');
+
+      // Load regular token balances first
+      const regularAssets = await loadTokenBalances(walletAddress, network || 'ethereum');
+
+      // Enhance with trusted contracts
+      const rpcUrl = getRpcUrl(network || 'ethereum');
+      const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+      const trustedAssetService = new TrustedContractsAssetService(network || 'ethereum', provider);
+
+      const enhancedAssets = await trustedAssetService.enhanceAssetsWithTrustedContracts(regularAssets, walletAddress);
+      setAssets(enhancedAssets);
+      console.log('✅ Token balances refreshed with trusted contract enhancement');
     } catch (error) {
       console.error('❌ Error refreshing token balances:', error);
     }


### PR DESCRIPTION
## Problem

When loading assets, pre-defined tokens from `TOKEN_ADDRESSES` were overwriting trusted contract tokens that had the same contract address. This happened in two places:

1. **Initial asset merging**: The `enhanceAssetsWithTrustedContracts` method was giving pre-defined tokens priority over trusted contract tokens
2. **Post-transaction refresh**: The `refreshTokenBalances` function was called after transactions and directly loaded pre-defined tokens without trusted contract enhancement

This meant that users who added tokens to their trusted contracts list would not see their custom names or the trusted badge, as the pre-defined token would take priority or overwrite them after transactions.

## Solution

Fixed both issues:

### 1. Enhanced Asset Merging Priority
Modified the `enhanceAssetsWithTrustedContracts` method in `TrustedContractsAssetService.ts` to:

- **Prioritize trusted contract tokens** over pre-defined tokens when there's a conflict
- **Replace pre-defined tokens** with trusted versions when they have the same contract address
- **Preserve trusted token features** like custom names (`"TrustedName (TokenName)"`) and `isTrusted: true` flag
- **Add comprehensive logging** to show when tokens are replaced or added for better debugging

### 2. Fixed Post-Transaction Refresh
Modified the `refreshTokenBalances` function in `WalletPage.tsx` to:

- **Load regular assets first** using the existing `loadTokenBalances` function
- **Enhance with trusted contracts** using `enhanceAssetsWithTrustedContracts` before setting assets
- **Maintain consistency** across all asset loading flows
- **Prevent trusted token loss** after transaction completion

## Changes

### Before
```typescript
// Old merging logic: Start with regular assets, only add trusted if no conflict
const combinedAssets = [...regularAssets];
for (const trustedAsset of trustedAssets) {
  if (!existingAddresses.has(trustedAsset.contractAddress.toLowerCase())) {
    combinedAssets.push(trustedAsset); // Only add if no conflict
  }
}

// Old refresh logic: Direct asset replacement without enhancement
const refreshedAssets = await loadTokenBalances(walletAddress, network);
setAssets(refreshedAssets); // Overwrites trusted tokens
```

### After
```typescript
// New merging logic: Replace regular assets with trusted versions when conflict exists
for (const regularAsset of regularAssets) {
  const trustedVersion = trustedAddressMap.get(regularAsset.contractAddress.toLowerCase());
  if (trustedVersion) {
    combinedAssets.push(trustedVersion); // Use trusted version
  } else {
    combinedAssets.push(regularAsset); // Use regular version
  }
}

// New refresh logic: Load regular assets then enhance with trusted contracts
const regularAssets = await loadTokenBalances(walletAddress, network);
const enhancedAssets = await trustedAssetService.enhanceAssetsWithTrustedContracts(regularAssets, walletAddress);
setAssets(enhancedAssets); // Preserves trusted tokens
```

## Benefits

- ✅ **Trusted contract tokens now have higher priority** over pre-defined tokens
- ✅ **Enhanced naming preserved**: Trusted tokens keep their `"TrustedName (TokenName)"` format
- ✅ **Trusted badge maintained**: `isTrusted: true` flag is preserved for UI display
- ✅ **No duplicates**: Prevents duplicate tokens with same contract address
- ✅ **Consistent behavior**: All asset loading flows now use trusted contract enhancement
- ✅ **Post-transaction persistence**: Trusted tokens remain visible after transactions
- ✅ **Better debugging**: Console messages show when replacements occur
- ✅ **Backward compatible**: Still works when no trusted contracts exist

## Example Scenarios

**Scenario 1 - Initial Loading**:
- **Before**: If USDC exists in both pre-defined tokens and trusted contracts, the pre-defined "USDC" would be shown
- **After**: The trusted contract version "My USDC Token (USD Coin)" with the ✓ TRUSTED badge will be shown instead

**Scenario 2 - Post-Transaction Refresh**:
- **Before**: After completing a transaction, trusted "My USDC Token" would be replaced with pre-defined "USDC"
- **After**: After completing a transaction, trusted "My USDC Token" with ✓ TRUSTED badge remains visible

## Testing

This change affects multiple asset loading flows in the wallet. To test:

1. Add a token to trusted contracts that also exists in `TOKEN_ADDRESSES` (e.g., USDC)
2. Load the wallet assets - verify trusted contract version is displayed
3. Complete a transaction - verify trusted contract version persists after refresh
4. Navigate between pages - verify trusted contract version remains consistent
5. Check console logs for replacement messages

## Files Changed

- `client/src/services/TrustedContractsAssetService.ts` - Fixed asset merging priority
- `client/src/components/wallet/WalletPage.tsx` - Fixed post-transaction refresh

Fixes the issue where trusted contract tokens were being ignored or overwritten by pre-defined tokens in multiple asset loading scenarios.