### PR TITLE
Increase header height to match WalletConnect dApp popup border

### DIFF
--- a/client/src/components/ui/Header.tsx
+++ b/client/src/components/ui/Header.tsx
@@ -189,7 +189,7 @@ const Header: React.FC<HeaderProps> = ({
     'flex justify-between items-center',
     'bg-white/5 backdrop-blur-md',
     'px-6 py-4 border-b border-gray-800',
-    'h-16 box-border relative overflow-visible',
+    'h-20 box-border relative overflow-visible',
     'z-50'
   );
 


### PR DESCRIPTION
## Summary

Increases the header height from 64px to 80px to match the visual alignment with the WalletConnect dApp popup modal.

## Changes

- Changed header height class from `h-16` (64px) to `h-20` (80px) in `Header.tsx`
- Aligns with the `DAppConnectionModal` which uses `paddingTop: '80px'`
- Improves visual consistency between header and modal positioning

## Testing

- [x] Header displays with increased height
- [x] Visual alignment with WalletConnect dApp popup is improved
- [x] No functional changes to existing behavior

## Files Changed

- `client/src/components/ui/Header.tsx`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author